### PR TITLE
Added option to build single fat-jar with dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,19 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>fully.qualified.MainClass</mainClass>
+            </manifest>
+          </archive>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <dependencies>


### PR DESCRIPTION
Common thing is to use this jar as a stand-alone dependency jar. Added maven task allows to build one single jar with all dependencies inside. 
